### PR TITLE
err process crash

### DIFF
--- a/app/models/trick.js
+++ b/app/models/trick.js
@@ -108,7 +108,7 @@ Trick.methods = {
           var errPrint     = {}
 
           if ( err.code == 11000 ) {
-            errPrint.message = 'Trick with title '+ doc.title + 'already exist';
+            errPrint.message = 'Trick with title '+ self.title + 'already exist';
             errPrint.status  = 409
           } else {
             errPrint = err


### PR DESCRIPTION
When submit repeats，self.save will return an error. In error process the doc.title leads to a crash. Because origin_url or title are indexed to unique.
